### PR TITLE
Add profile, config, credentials file option overrides

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -165,7 +165,13 @@ func writeAtomic(dest string, r io.Reader) (int64, error) {
 		}
 	}()
 	if err = os.Rename(tempFile, dest); err != nil {
-		return 0, err
+		_, err := os.Stat(dest)
+		if err == nil {
+			log.Println(tempFile, err, "reason: already exists on disk")
+		} else {
+			log.Println(tempFile, err)
+		}
+		return size, nil
 	}
 	return size, nil
 }


### PR DESCRIPTION
In an environment where default AWS credentials are already serving a difference purpose, it can be hard to select what gocacheprog-s3 will use.

This is especially true because you cannot environment variables in `GOCACHEPROG`, and in my environment at least, it's hard to temporary set `AWS_PROFILE` before every use of `go build`/`go test` etc. Exposing the options as command line options make it much easier.